### PR TITLE
Update cwp-search to 1.1.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "silverstripe/recipe-plugin": "^1",
-        "cwp/cwp-search": "1.0.x-dev",
+        "cwp/cwp-search": "1.1.x-dev",
         "silverstripe/fulltextsearch": "3.3.x-dev",
         "symbiote/silverstripe-queuedjobs": "4.2.x-dev"
     },


### PR DESCRIPTION
Requires https://github.com/silverstripe/cwp-search/pull/12 to be merged first, then have the correct branch created in that repository